### PR TITLE
start threads as daemons

### DIFF
--- a/nrf802154_sniffer/nrf802154_sniffer.py
+++ b/nrf802154_sniffer/nrf802154_sniffer.py
@@ -464,6 +464,7 @@ class Nrf802154Sniffer(object):
         self.threads.append(threading.Thread(target=self.fifo_writer, args=(fifo, packet_queue), name="fifo_writer"))
 
         for thread in self.threads:
+            thread.daemon = True
             thread.start()
 
         while is_standalone and self.running.is_set():


### PR DESCRIPTION
Sometimes not all threads, started by sniffer, are stopped after executing "stop_sig_handler" which leads to suspended scripts/tests (sniffer threads are still alive after main thread is closed)