### PR TITLE
Update nrf802154_sniffer.py

### DIFF
--- a/nrf802154_sniffer/nrf802154_sniffer.py
+++ b/nrf802154_sniffer/nrf802154_sniffer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2019, Nordic Semiconductor ASA
 # All rights reserved.


### PR DESCRIPTION
The keyword python is no longer works on Ubuntu 22.04, fixing for https://github.com/NordicSemiconductor/nRF-Sniffer-for-802.15.4/issues/62