### PR TITLE
Render script compatible with pyinstaller

### DIFF
--- a/nrf802154_sniffer/nrf802154_sniffer.py
+++ b/nrf802154_sniffer/nrf802154_sniffer.py
@@ -36,7 +36,6 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
 # OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from enum import IntEnum
 import sys
 import os
 
@@ -56,9 +55,10 @@ from argparse import ArgumentParser
 from binascii import a2b_hex
 from serial import Serial, SerialException
 from serial.tools.list_ports import comports
-from multiprocessing import Queue, Process
+from multiprocessing import Queue, Process, freeze_support
 from dataclasses import dataclass
 from threading import Thread
+from enum import IntEnum
 
 
 @dataclass
@@ -513,6 +513,7 @@ class Nrf802154Sniffer:
 
 
 if is_standalone:
+    freeze_support()
     args = Nrf802154Sniffer.parse_args()
 
     logging.basicConfig(


### PR DESCRIPTION
After discussion in #75 

freeze_support has no effect other than helping pyinstaller support multiprocessing 
https://pyinstaller.org/en/stable/common-issues-and-pitfalls.html#multi-processing
https://docs.python.org/3/library/multiprocessing.html#multiprocessing.freeze_support


> If the freeze_support() line is omitted then trying to run the frozen executable will raise [RuntimeError](https://docs.python.org/3/library/exceptions.html#RuntimeError).
> 
> Calling freeze_support() has no effect when invoked on any operating system other than Windows. In addition, if the module is being run normally by the Python interpreter on Windows (the program has not been frozen), then freeze_support() has no effect.